### PR TITLE
Fix: OwlyWindow.quit() not being called on window destroy event

### DIFF
--- a/assets/owlywindow.glade
+++ b/assets/owlywindow.glade
@@ -59,7 +59,7 @@
     <property name="default_height">400</property>
     <property name="type_hint">dialog</property>
     <property name="gravity">center</property>
-    <signal name="destroy-event" handler="quit" swapped="no"/>
+    <signal name="destroy" handler="quit" swapped="no"/>
     <child>
       <object class="GtkBox" id="main_window_internal">
         <property name="visible">True</property>

--- a/audio-owl.py
+++ b/audio-owl.py
@@ -138,7 +138,7 @@ class OwlyWindow(Gtk.ApplicationWindow):
                 self.player.audio_set_volume(
                     int(self.ramp_down(self.player.get_time())*100))
 
-    def quit(self, widget):
+    def quit(self, *args, **kwargs):
         """Quit Audio-Owl
         
         Stop the audio, kill the threads and kill Gtk.main()


### PR DESCRIPTION
This commit fixes changes the event-handler that calls OwlyWindow.quit()
from `destroy-event` to `destroy`. Also change quit() to accept a list
of args and kwargs since we don't actually need to use them right now.
Probably not the best way but we don't care so as long as quit gets
called.